### PR TITLE
Fix Module Path Case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {plugin} from "./plugin/plugin";
+import {plugin} from "./plugin/Plugin";
 
 // Export the plugin function that will be used in the gulp pipeline.
 export = plugin;


### PR DESCRIPTION
File paths including node module paths need to have the correct case to
work in operating systems other than windows which are case-sensitive.